### PR TITLE
 Replace path.package() with find.package()

### DIFF
--- a/R/cbsa.R
+++ b/R/cbsa.R
@@ -1,3 +1,3 @@
 .onLoad <- function(libname, pkgname) {
-  #print(path.package('cbsa'))
+  #print(find.package('cbsa'))
 }

--- a/R/importing_data.R
+++ b/R/importing_data.R
@@ -10,10 +10,10 @@ import_ffiec <- function(year) {
     year <- as.numeric(year)
 
   file_name <- sprintf('%s/data/original_data/msa%02dinc.xls',
-                       path.package('cbsa'),
+                       find.package('cbsa'),
                        year %% 100)
   out_file <- sprintf('%s/data/mfi_definitions_%04d.txt',
-                      path.package('cbsa'),
+                      find.package('cbsa'),
                       as.integer(year))
 
   if (!file.exists(file_name))
@@ -68,7 +68,7 @@ import_omb <- function(in_file) {
   }
   comment(out_data) <- extract_yyyymm(in_file)
 
-  file.path(path.package('cbsa'),
+  file.path(find.package('cbsa'),
             sprintf('data/%s_definition_%s.txt',
                     file_type,
                     comment(out_data))) %>%
@@ -243,7 +243,7 @@ import_census <- function() {
   list(acs_data, dec_data) %>%
     bind_rows() %>%
     mutate(tract = as.numeric(tract)) %>%
-    write.table(file = file.path(path.package('cbsa'),
+    write.table(file = file.path(find.package('cbsa'),
                                  'data/tract_mfi_levels.txt'),
                 sep = '\t')
 

--- a/R/loading.R
+++ b/R/loading.R
@@ -57,7 +57,7 @@ load_mfi <- function(year) {
 #' @export
 load_cbsa <- function(date) {
   determine_file_date(date) %>%
-    sprintf('%s/data/cbsa_definition_%d.rds', path.package('cbsa'), .) %>%
+    sprintf('%s/data/cbsa_definition_%d.txt', path.package('cbsa'), .) %>%
     read.table(sep = '\t')
 }
 
@@ -68,7 +68,7 @@ load_cbsa <- function(date) {
 #' @export
 load_necta <- function(date) {
   determine_file_date(date) %>%
-    sprintf('%s/data/necta_definition_%d.rds', path.package('cbsa'), .) %>%
+    sprintf('%s/data/necta_definition_%d.txt', path.package('cbsa'), .) %>%
     read.table(sep = '\t')
 }
 
@@ -86,7 +86,7 @@ determine_file_date <- function(date) {
     date <- (date * 100) + 1
 
   date_list <- list.files(path = sprintf('%s/data', path.package('cbsa')),
-                          pattern = 'cbsa_[a-z0-9_]*.rds',
+                          pattern = 'cbsa_[a-z0-9_]*.txt',
                           full.names = TRUE) %>%
     extract_yyyymm() %>%
     as.numeric() %>%

--- a/R/loading.R
+++ b/R/loading.R
@@ -41,7 +41,7 @@ assign_cbsa <- function(tract, county_fips, date = format(Sys.Date(), '%Y%m'),
 #' @export
 load_mfi <- function(year) {
   file_name <- sprintf('%s/data/mfi_definitions_%d.txt',
-                       path.package('cbsa'),
+                       find.package('cbsa'),
                        year)
   if (!file.exists(file_name))
     stop(paste0('Median family income file not found for year ', year))
@@ -57,7 +57,7 @@ load_mfi <- function(year) {
 #' @export
 load_cbsa <- function(date) {
   determine_file_date(date) %>%
-    sprintf('%s/data/cbsa_definition_%d.txt', path.package('cbsa'), .) %>%
+    sprintf('%s/data/cbsa_definition_%d.txt', find.package('cbsa'), .) %>%
     read.table(sep = '\t')
 }
 
@@ -68,7 +68,7 @@ load_cbsa <- function(date) {
 #' @export
 load_necta <- function(date) {
   determine_file_date(date) %>%
-    sprintf('%s/data/necta_definition_%d.txt', path.package('cbsa'), .) %>%
+    sprintf('%s/data/necta_definition_%d.txt', find.package('cbsa'), .) %>%
     read.table(sep = '\t')
 }
 
@@ -85,7 +85,7 @@ determine_file_date <- function(date) {
   if (date < 10000)
     date <- (date * 100) + 1
 
-  date_list <- list.files(path = sprintf('%s/data', path.package('cbsa')),
+  date_list <- list.files(path = sprintf('%s/data', find.package('cbsa')),
                           pattern = 'cbsa_[a-z0-9_]*.txt',
                           full.names = TRUE) %>%
     extract_yyyymm() %>%
@@ -115,7 +115,8 @@ determine_file_date <- function(date) {
 #' to be returned or the relative income (default = TRUE)
 #' @return Either the relative income (if return_label == FALSE) or the income level
 #' @export
-assign_lmi <- function(search_tract, year, return_label = TRUE) {
+assign_lmi <- function(search_tract, year, return_label = TRUE,
+                       use_md = TRUE, only_metro = TRUE, assign_nonmetro = TRUE) {
   if (missing(search_tract))
     stop('Must supply tract to assign_lmi')
   if (missing(year))
@@ -135,14 +136,15 @@ assign_lmi <- function(search_tract, year, return_label = TRUE) {
     use_file <- 'acs_2015'
   }
 
-  mfi_data <- file.path(path.package('cbsa'),
+  mfi_data <- file.path(find.package('cbsa'),
                         'data/tract_mfi_levels.txt') %>%
     read.table(sep = '\t') %>%
     filter(file == use_file) %>%
     mutate(cbsa = assign_cbsa(tract = tract,
                               date = (year * 100) + 1,
-                              only_metro = TRUE,
-                              assign_nonmetro = TRUE)) %>%
+                              use_md = use_md,
+                              only_metro = only_metro,
+                              assign_nonmetro = assign_nonmetro)) %>%
     mutate(cbsa = ifelse(is.na(cbsa), 99900 + floor(tract / 1e9), cbsa))
 
   ffiec_data <- load_mfi(year) %>%
@@ -163,7 +165,7 @@ assign_lmi <- function(search_tract, year, return_label = TRUE) {
 }
 
 latest_year <- function() {
-  list.files(path = file.path(path.package('cbsa'),
+  list.files(path = file.path(find.package('cbsa'),
                               'data'),
              pattern = 'mfi_definitions') %>%
     gsub('.*_([0-9]{4}).*', '\\1', .) %>%

--- a/R/loading.R
+++ b/R/loading.R
@@ -141,7 +141,7 @@ assign_lmi <- function(search_tract, year, return_label = TRUE) {
     filter(file == use_file) %>%
     mutate(cbsa = assign_cbsa(tract = tract,
                               date = (year * 100) + 1,
-                              only_metro = FALSE,
+                              only_metro = TRUE,
                               assign_nonmetro = TRUE)) %>%
     mutate(cbsa = ifelse(is.na(cbsa), 99900 + floor(tract / 1e9), cbsa))
 

--- a/man/assign_lmi.Rd
+++ b/man/assign_lmi.Rd
@@ -4,7 +4,8 @@
 \alias{assign_lmi}
 \title{Assign Income Level}
 \usage{
-assign_lmi(search_tract, year, return_label = TRUE)
+assign_lmi(search_tract, year, return_label = TRUE, use_md = TRUE,
+  only_metro = TRUE, assign_nonmetro = TRUE)
 }
 \arguments{
 \item{search_tract}{Numeric vector of Census tract codes (11 digits)}

--- a/man/assign_lmi.Rd
+++ b/man/assign_lmi.Rd
@@ -4,10 +4,10 @@
 \alias{assign_lmi}
 \title{Assign Income Level}
 \usage{
-assign_lmi(tract, year, return_label = TRUE)
+assign_lmi(search_tract, year, return_label = TRUE)
 }
 \arguments{
-\item{tract}{Numeric vector of Census tract codes (11 digits)}
+\item{search_tract}{Numeric vector of Census tract codes (11 digits)}
 
 \item{year}{A numeric year (YYYY)}
 


### PR DESCRIPTION
path.package() was giving me an error when called without cbsa being loaded:

```r
cbsa::assign_lmi(tract, year)
Error in path.package("cbsa") : none of the packages are loaded
```

find.package() seems to work, but IDK if it's best practice. [Hadley](http://r-pkgs.had.co.nz/data.html) seems to recommend storing data in .RData files.